### PR TITLE
Resolves #173, added in debug toggles

### DIFF
--- a/src/me/dreamteam/tardis/EnemyEntity.java
+++ b/src/me/dreamteam/tardis/EnemyEntity.java
@@ -31,7 +31,9 @@ public class EnemyEntity extends Entity {
 		if ((dy > 0) && (y > 750)) {
 			game.updateLogic();
             game.removeEntity(this);
+            if (game.debug) {
             System.out.println("DEBUG: (GC) Removed " + this + " as it had reached the bottom");
+            }
 		
 		}
 		
@@ -41,7 +43,15 @@ public class EnemyEntity extends Entity {
 	public void collidedWith(Entity other) {
 		if (other instanceof ShipEntity) {
             // remove the affected entities
-            game.removeEntity(this);
+			game.gameLives--;
+			game.removeEntity(this);
+		}
+		
+		if (other instanceof EnemyEntity) {
+			if (game.debug) {
+			game.debugHits++;
+            System.out.println("DEBUG: (-) Enemy " + this + " hit " + other);
+			}
 		}
 	
 	

--- a/src/me/dreamteam/tardis/Game.java
+++ b/src/me/dreamteam/tardis/Game.java
@@ -41,6 +41,9 @@ public class Game extends Canvas {
 	private BufferStrategy strategy;
 	// This provides hardware acceleration
 	
+	public boolean debug = false;
+	// Enable this if you want to see debug in console
+	
 	private boolean isRunning = true;
 	private boolean gameStart = false;
 	long lastLoopTime;
@@ -288,9 +291,11 @@ public class Game extends Canvas {
 		   //get current date time with Date()
 		   Date date = new Date();
 		
+		if (debug) {
 		System.out.println("=============================================");
 		System.out.println("Beginning session @" + dateFormat.format(date));
 		System.out.println("=============================================");
+		}
         
 	}
 	
@@ -359,10 +364,13 @@ public class Game extends Canvas {
 	}
 	
 	public void gameOver() {
+		if (debug) {
 		System.out.println("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
 		System.out.println("GAME OVER DISPLAYED AFTER " + gameTime + " SECONDS");
 		System.out.println("HITS:" + debugHits + "/3");
 		System.out.println("LEVEL: " + level);
+		}
+		
 		ImageIcon icon = new ImageIcon(Utils.iconURL);	
 		Utils.systemLF();
 		
@@ -483,9 +491,7 @@ public class Game extends Canvas {
 	            		
 	            		if (me.collidesWith(him)) {
 	            			me.collidedWith(him);
-	            			him.collidedWith(me);
-	            			debugHits++;
-	            			gameLives--;      
+	            			him.collidedWith(me); 
 	            			
 	            		}
 	            	}

--- a/src/me/dreamteam/tardis/ShipEntity.java
+++ b/src/me/dreamteam/tardis/ShipEntity.java
@@ -25,7 +25,9 @@ public class ShipEntity extends Entity {
 	
             // what to do if collied
             if (other instanceof EnemyEntity) {
-                System.out.println("DEBUG: Enemy Hit " + other);
+            	if (game.debug) {
+                System.out.println("DEBUG: (-) Enemy Hit " + other);
+            	}
             }
     }
 		


### PR DESCRIPTION
Lives should not drop when enemies collide into each other.

Was tested first using remove on collide, which shows that entities collide a lot in level 2 onwards.
