### PR TITLE
Make Game over visible

### DIFF
--- a/src/me/dreamteam/tardis/Game.java
+++ b/src/me/dreamteam/tardis/Game.java
@@ -337,7 +337,7 @@ public class Game extends Canvas {
 		Graphics2D g2 = (Graphics2D) properties.strategy.getDrawGraphics();
 		g2.setColor(Color.red);
 		g2.setFont(new Font("Lucida Console", Font.BOLD, 32));
-        g2.drawString("Game Over",(500-g2.getFontMetrics().stringWidth("Game Over"))/2,300);
+        g2.drawString("Game Over",(500-g2.getFontMetrics().stringWidth("Game Over"))/2,80);
         properties.strategy.show();
         g2.dispose();
         


### PR DESCRIPTION
Was hidden behind the message dialog.

Alternatively, text could show in centre, followed by a 3 second pause,
then the message dialog?
