### PR TITLE
Make Maven use a final name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,8 @@
                         </goals>
                         <phase>package</phase>
                         <configuration>
+                            <finalName>SSA</finalName>
+                            <appendAssemblyId>false</appendAssemblyId>
                             <descriptorRefs>
                                 <descriptorRef>jar-with-dependencies</descriptorRef>
                             </descriptorRefs>


### PR DESCRIPTION
This means that it should build as "SSA.jar" without version number in
some cases.
